### PR TITLE
Single tap to zoom out. Single tap or drag to dismiss.

### DIFF
--- a/Vertigo/TGRImageViewController.h
+++ b/Vertigo/TGRImageViewController.h
@@ -26,7 +26,7 @@
 //
 // Allows the user to view an image in full screen and double tap to zoom it.
 // The view controller can be dismissed with a single tap.
-@interface TGRImageViewController : UIViewController
+@interface TGRImageViewController : UIViewController <UIScrollViewDelegate>
 
 // The scroll view used for zooming.
 @property (weak, nonatomic) IBOutlet UIScrollView *scrollView;

--- a/Vertigo/TGRImageViewController.h
+++ b/Vertigo/TGRImageViewController.h
@@ -26,7 +26,7 @@
 //
 // Allows the user to view an image in full screen and double tap to zoom it.
 // The view controller can be dismissed with a single tap.
-@interface TGRImageViewController : UIViewController <UIScrollViewDelegate>
+@interface TGRImageViewController : UIViewController
 
 // The scroll view used for zooming.
 @property (weak, nonatomic) IBOutlet UIScrollView *scrollView;

--- a/Vertigo/TGRImageViewController.m
+++ b/Vertigo/TGRImageViewController.m
@@ -44,6 +44,9 @@
     
     [self.singleTapGestureRecognizer requireGestureRecognizerToFail:self.doubleTapGestureRecognizer];
     self.imageView.image = self.image;
+    self.scrollView.delegate = self;
+    self.scrollView.bounces = YES;
+    self.scrollView.alwaysBounceVertical = YES;
 }
 
 - (BOOL)prefersStatusBarHidden {
@@ -56,10 +59,22 @@
     return self.imageView;
 }
 
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+    if (self.scrollView.zoomScale == self.scrollView.minimumZoomScale) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
+}
+
 #pragma mark - Private methods
 
 - (IBAction)handleSingleTap:(UITapGestureRecognizer *)tapGestureRecognizer {
-    [self dismissViewControllerAnimated:YES completion:nil];
+    if (self.scrollView.zoomScale == self.scrollView.minimumZoomScale) {
+        [self dismissViewControllerAnimated:YES completion:nil];
+    }
+    else {
+        // Zoom out
+        [self.scrollView zoomToRect:self.scrollView.bounds animated:YES];
+    }
 }
 
 - (IBAction)handleDoubleTap:(UITapGestureRecognizer *)tapGestureRecognizer {

--- a/Vertigo/TGRImageViewController.m
+++ b/Vertigo/TGRImageViewController.m
@@ -44,9 +44,6 @@
     
     [self.singleTapGestureRecognizer requireGestureRecognizerToFail:self.doubleTapGestureRecognizer];
     self.imageView.image = self.image;
-    self.scrollView.delegate = self;
-    self.scrollView.bounces = YES;
-    self.scrollView.alwaysBounceVertical = YES;
 }
 
 - (BOOL)prefersStatusBarHidden {

--- a/Vertigo/TGRImageViewController.xib
+++ b/Vertigo/TGRImageViewController.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4510" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3742"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="TGRImageViewController">
@@ -18,7 +18,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" maximumZoomScale="2" id="mKd-iv-BEJ">
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" maximumZoomScale="2" id="mKd-iv-BEJ">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <subviews>

--- a/Vertigo/TGRImageZoomAnimationController.m
+++ b/Vertigo/TGRImageZoomAnimationController.m
@@ -71,6 +71,8 @@
     // Perform the transition using a spring motion effect
     NSTimeInterval duration = [self transitionDuration:transitionContext];
     
+    self.referenceImageView.alpha = 0;
+    
     [UIView animateWithDuration:duration
                           delay:0
          usingSpringWithDamping:0.7
@@ -136,6 +138,7 @@
                          toViewController.view.alpha = 1;
                          transitionView.frame = transitionViewFinalFrame;
                      } completion:^(BOOL finished) {
+                         self.referenceImageView.alpha = 1;
                          [transitionView removeFromSuperview];
                          [transitionContext completeTransition:YES];
                      }];


### PR DESCRIPTION
Fix. 
Hides image view before zoom-in transition and shows it after zoom-out
transition. This prevents still image showing behind the zoom-in transition.

Update.
Instead of single tap to dismiss while zoomed in, single tap will zoom
back out. When zoomed out, single tap or draggin will dismiss. Facebook style.
