### PR TITLE
Fix

### DIFF
--- a/Vertigo/TGRImageZoomAnimationController.h
+++ b/Vertigo/TGRImageZoomAnimationController.h
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 // Image zoom custom transition.
 @interface TGRImageZoomAnimationController : NSObject <UIViewControllerAnimatedTransitioning>

--- a/Vertigo/TGRImageZoomAnimationController.m
+++ b/Vertigo/TGRImageZoomAnimationController.m
@@ -86,6 +86,7 @@
                          fromViewController.view.alpha = 1;
                          
                          [transitionView removeFromSuperview];
+                         toViewController.view.frame = transitionContext.containerView.frame;
                          [transitionContext.containerView addSubview:toViewController.view];
                          
                          [transitionContext completeTransition:YES];


### PR DESCRIPTION
Had a bug related with orientation change when origin view controller in portrait mode.
So, toViewController.view.frame != transitionContext.containerView.frame sometimes
