### PR TITLE
toViewController always return the same frame

### DIFF
--- a/Vertigo/TGRImageZoomAnimationController.m
+++ b/Vertigo/TGRImageZoomAnimationController.m
@@ -87,7 +87,7 @@
                          
                          [transitionView removeFromSuperview];
                          [transitionContext.containerView addSubview:toViewController.view];
-                         
+                         toViewController.view.frame = [UIScreen mainScreen].bounds;
                          [transitionContext completeTransition:YES];
                      }];
 }


### PR DESCRIPTION
make toViewController have the right frame, when i include the library in my project, i find the TGRImageViewController.view does not have the right frame, so i set the TGRImageViewController.view before add to the content view.
